### PR TITLE
Add in a tab-smart-sort:sort-existing-tabs command

### DIFF
--- a/lib/tab-smart-sort.coffee
+++ b/lib/tab-smart-sort.coffee
@@ -121,6 +121,7 @@ sortAllItems = ->
 
       pane.moveItem item.item, newIndex
 
+  # This is to prevent `while` from returning an array
   undefined
 
 module.exports = new TabSmartSort

--- a/lib/tab-smart-sort.coffee
+++ b/lib/tab-smart-sort.coffee
@@ -112,7 +112,8 @@ sortAllItems = ->
     else
       # Because this algorithm moves from left-to-right, all the previous
       # items are already sorted, so the newIndex must be to the right
-      newIndex = sorted.indexOf item
+      # TODO verify that this is never -1
+      newIndex = sorted.indexOf item, index + 1
 
       # This must match the algorithm for pane.moveItem
       items.splice index, 1

--- a/lib/tab-smart-sort.coffee
+++ b/lib/tab-smart-sort.coffee
@@ -8,7 +8,7 @@ sortTerms = caseSensitive = placeSpecialTabsOnRight = null
 originalAddItem = panePrototype = null
 
 class TabSmartSort
-  
+
   config:
     caseSensitive:
       type: 'boolean'
@@ -19,23 +19,23 @@ class TabSmartSort
     placeSpecialTabsOnRight:
       type: 'boolean'
       default: no
-  
+
   activate: ->
     setOrdering = (order) ->
       sortTerms = (term.replace(/[^a-zA-Z]/g, '') for term in order.split /[\s,;:-]/)
-      
+
     caseSensitive           = atom.config.get 'tab-smart-sort.caseSensitive'
-    setOrdering               atom.config.get 'tab-smart-sort.ordering' 
+    setOrdering               atom.config.get 'tab-smart-sort.ordering'
     placeSpecialTabsOnRight = atom.config.get 'tab-smart-sort.placeSpecialTabsOnRight'
-    
+
     @disp = []
-    @disp.push atom.config.observe 'tab-smart-sort.caseSensitive', 
+    @disp.push atom.config.observe 'tab-smart-sort.caseSensitive',
       (val) -> caseSensitive = val
-    @disp.push atom.config.observe 'tab-smart-sort.ordering', 
+    @disp.push atom.config.observe 'tab-smart-sort.ordering',
       (val) -> setOrdering val
-    @disp.push atom.config.observe 'tab-smart-sort.placeSpecialTabsOnRight', 
+    @disp.push atom.config.observe 'tab-smart-sort.placeSpecialTabsOnRight',
       (val) -> placeSpecialTabsOnRight = val
-    
+
     panePrototype = atom.workspace.getActivePane().__proto__
     originalAddItem = panePrototype.addItem
     panePrototype.addItem = addItem
@@ -43,9 +43,9 @@ class TabSmartSort
   deactivate: ->
     for disp in @disp then disp.dispose()
     panePrototype.addItem = originalAddItem
-  
+
 getSortStr = (item) ->
-  if not (path = item.getPath?()) 
+  if not (path = item.getPath?())
     return (if placeSpecialTabsOnRight then '~~~~~~~~~' else '')
   sortStr = ''
   for term in sortTerms

--- a/lib/tab-smart-sort.coffee
+++ b/lib/tab-smart-sort.coffee
@@ -122,6 +122,6 @@ sortAllItems = ->
       pane.moveItem item.item, newIndex
 
   # This is to prevent `while` from returning an array
-  undefined
+  return
 
 module.exports = new TabSmartSort


### PR DESCRIPTION
The `tab-smart-sort:sort-existing-tabs` command sorts the existing tabs in the current pane

Fixes issue #11